### PR TITLE
fix shebang for venv

### DIFF
--- a/system
+++ b/system
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 
 import os
 import sys

--- a/user
+++ b/user
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/python3
 
 import os
 import yaml
@@ -266,7 +266,7 @@ def apply_cadre(path):
                 for cmd in commands:
                     creation_env = os.environ.copy()
                     creation_env['BLEND_NO_CHECK'] = 'true'
-                    subprocess.run(['blend', 'enter', '-cn', container, '--', *cmd], env=creation_env)
+                    subprocess.run(['/home/zephyr/dev/blend/blend/blend', 'enter', '-cn', container, '--', *cmd], env=creation_env)
                 info(
                     f'finished running all commands for {colors.bold}{container}{colors.reset}')
                 print()
@@ -386,7 +386,7 @@ def shell(container):
         exit(1)
     creation_env = os.environ.copy()
     creation_env['BLEND_NO_CHECK'] = 'true'
-    subprocess.run(['blend', 'enter', '-cn', container], env=creation_env)
+    subprocess.run(['/home/zephyr/dev/blend/blend-blend/blend', 'enter', '-cn', container], env=creation_env)
 
 
 @cli.command("exec")


### PR DESCRIPTION
Trying to call any blend user, system, or associations while a python virtualenv is activated fail if the virtualenv doesn't have blend's dependencies installed in its site-packages.

Switching the shebang to use /usr/bin/python3 fixes this because it no longer uses the venv python.