### PR TITLE
Testing gnome user module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,8 @@
+"""Minimal setup.py to let tox run."""
+
+from setuptools import find_packages, setup
+
+setup(
+    name="system",
+    packages=find_packages(exclude=["tests"])
+)

--- a/tests/test_gnome_user_module.py
+++ b/tests/test_gnome_user_module.py
@@ -1,0 +1,44 @@
+from user_modules.gnome import call
+
+
+def test_config_setting_gtk_theme():
+    assert call({"gtk-theme": 'adw-gtk3'}) == {
+        "commands": [
+            ['gsettings', 'set', 'org.gnome.desktop.interface', 'gtk-theme', 'adw-gtk3']
+        ]
+    }
+
+
+def test_config_setting_icon_theme():
+    assert call({"icon-theme": 'Adwaita'}) == {
+        "commands": [
+            ['gsettings', 'set', 'org.gnome.desktop.interface', 'icon-theme', 'Adwaita']
+        ]
+    }
+
+
+def test_config_setting_style():
+    assert call({"style": "light"}) == {
+        "commands": [
+            ['gsettings', 'set', 'org.gnome.desktop.interface', 'color-scheme', 'prefer-light']
+        ]
+    }
+
+
+def test_config_titlebar():
+
+    assert call({
+        "titlebar": {
+            "button-placement": "right",
+            "double-click-action": "toggle-maximize",
+            "middle-click-action": "minimize",
+            "right-click-action": "menu"
+        }
+    }) == {
+        "commands": [
+            ['gsettings', 'set', 'org.gnome.desktop.wm.preferences', 'button-layout', 'appmenu:minimize,maximize,close'],
+            ['gsettings', 'set', 'org.gnome.desktop.wm.preferences', 'action-double-click-titlebar', "toggle-maximize"],
+            ['gsettings', 'set', 'org.gnome.desktop.wm.preferences', 'action-middle-click-titlebar', "minimize"],
+            ['gsettings', 'set', 'org.gnome.desktop.wm.preferences', 'action-right-click-titlebar', "menu"]
+        ]
+    }

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,15 @@
+[tox]
+env_list =
+    py311
+minversion = 4.11.1
+
+
+[testenv]
+description = run the tests with pytest
+package = wheel
+wheel_build_env = .pkg
+deps =
+    pytest>=6
+commands =
+    pytest {tty:--color=yes} {posargs}
+

--- a/user_modules/gnome.py
+++ b/user_modules/gnome.py
@@ -12,7 +12,7 @@ def call(config):
 
     if type(config.get('icon-theme')) == str:
         return_val['commands'].append(
-            ['gsettings', 'set', 'org.gnome.desktop.interface', 'icon-theme', config.get('gtk-theme')])
+            ['gsettings', 'set', 'org.gnome.desktop.interface', 'icon-theme', config.get('icon-theme')])
 
     if type(config.get('style')) == str:
         return_val['commands'].append(


### PR DESCRIPTION
Hello,

I would like to extend _user_ command so it can generate a cadre file based on the current installation of a user.
In this context, I'm looking around in the project to understand and in this context I started to write some unit tests.

One of those tests revealed a bug in user_module.gnome.call function. gtk-theme value in config dict was used to set the icon-theme.

I will probably come with further small enhancements to achieve generating cadre file for an existing install. :smile: 